### PR TITLE
Chris/ao normal optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Framework/
 
 .build
 
+.swiftpm
+

--- a/Sources/Common/GLTFLoadOptions.swift
+++ b/Sources/Common/GLTFLoadOptions.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  
+//
+//  Created by Chris Heinrich on 8/4/21.
+//
+
+import Foundation
+
+
+
+public enum GLTFOption: Equatable {
+    case skipNormalMap // whether to skip loading normal map
+    case skipAOMap // whether to skip loading AO map
+    case maxTextureSize1k
+    case maxTextureSize2k
+    case maxTextureSize4k
+}
+
+public struct GLTFLoadOptions {
+    private(set) var options: [GLTFOption]
+    
+    public init(_ options: [GLTFOption] = []) {
+        self.options = options
+    }
+    
+    var skipNormalMap: Bool {
+        return options.contains(.skipNormalMap)
+    }
+    
+    var skipAOMap: Bool {
+        return options.contains(.skipAOMap)
+    }
+    
+    var maxTextureSize: Int? {
+        // go from smallest to largest
+        if options.contains(.maxTextureSize1k) {
+            return 1024
+        } else if options.contains(.maxTextureSize2k) {
+            return 2048
+        } else if options.contains(.maxTextureSize4k) {
+            return 4096
+        }
+        return nil
+    }
+    
+}
+

--- a/Sources/Common/GLTFSceneSource.swift
+++ b/Sources/Common/GLTFSceneSource.swift
@@ -28,11 +28,11 @@ public class GLTFSceneSource : SCNSceneSource {
         self.loader = loader
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil, gltfOptions: [GLTFLoadOption] = []) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil, gltfOptions: GLTFLoadOptions = .init()) {
         self.init(url: url, options: options, extensions: nil, gltfOptions: gltfOptions)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, gltfOptions: [GLTFLoadOption]) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, gltfOptions: GLTFLoadOptions = .init()) {
         self.init()
         
         do {

--- a/Sources/Common/GLTFSceneSource.swift
+++ b/Sources/Common/GLTFSceneSource.swift
@@ -28,15 +28,15 @@ public class GLTFSceneSource : SCNSceneSource {
         self.loader = loader
     }
     
-    public override convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil) {
-        self.init(url: url, options: options, extensions: nil)
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil, gltfOptions: [GLTFLoadOption] = []) {
+        self.init(url: url, options: options, extensions: nil, gltfOptions: gltfOptions)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, gltfOptions: [GLTFLoadOption]) {
         self.init()
         
         do {
-            self.loader = try GLTFUnarchiver(url: url, extensions: extensions)
+            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, options: gltfOptions)
         } catch {
             print("\(error.localizedDescription)")
         }
@@ -64,7 +64,7 @@ public class GLTFSceneSource : SCNSceneSource {
             throw GLTFSceneSourceError.nilLoader
         }
 
-        let scene = try self.loader.loadScene()
+        let scene = try loader.loadScene()
         #if SEEMS_TO_HAVE_SKINNER_VECTOR_TYPE_BUG
             let sceneData = NSKeyedArchiver.archivedData(withRootObject: scene)
             let source = SCNSceneSource(data: sceneData, options: nil)!

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -1012,18 +1012,21 @@ public class GLTFUnarchiver {
         }
         
         if let normalTexture = glMaterial.normalTexture {
-            print("Loading normal texture")
+            print("Skipping normal map")
+            /*
             try self.setTexture(index: normalTexture.index, to: material.normal)
             material.normal.mappingChannel = normalTexture.texCoord
-            
+            */
             // TODO: - use normalTexture.scale
         }
         
         if let occlusionTexture = glMaterial.occlusionTexture {
-            print("Loading occlusion texture")
+            print("Skipping AO map")
+            /*
             try self.setTexture(index: occlusionTexture.index, to: material.ambientOcclusion)
             material.ambientOcclusion.mappingChannel = occlusionTexture.texCoord
             material.ambientOcclusion.intensity = CGFloat(occlusionTexture.strength)
+            */
         }
         
         if let emissiveTexture = glMaterial.emissiveTexture {

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -15,6 +15,13 @@ let glbMagic = 0x46546C67 // "glTF"
 let chunkTypeJSON = 0x4E4F534A // "JSON"
 let chunkTypeBIN = 0x004E4942 // "BIN"
 
+
+public enum GLTFLoadOption {
+    case skipNormalMap // whether to skip loading normal map (to save memory)
+    case skipAOMap // whether to skip loading AO map (to save memory)
+    case maxTextureSize4k // will resize any texture/material map larger than 4k to 4k
+}
+
 public class GLTFUnarchiver {
     private var directoryPath: URL? = nil
     private var json: GLTFGlTF! = nil
@@ -37,14 +44,14 @@ public class GLTFUnarchiver {
     private var textures: [SCNMaterialProperty?] = []
     private var images: [Image?] = []
     private var maxAnimationDuration: CFTimeInterval = 0.0
+    private(set) var options: [GLTFLoadOption] = []
 
-    private(set) var loadAlbedoOnly = true
     
     #if !os(watchOS)
         private var workingAnimationGroup: CAAnimationGroup! = nil
     #endif
     
-    convenience public init(path: String, extensions: [String:Codable.Type]? = nil) throws {
+    convenience public init(path: String, extensions: [String:Codable.Type]? = nil, options: [GLTFLoadOption] = []) throws {
         var url: URL?
         if let mainPath = Bundle.main.path(forResource: path, ofType: "") {
             url = URL(fileURLWithPath: mainPath)
@@ -54,13 +61,14 @@ public class GLTFUnarchiver {
         guard let _url = url else {
             throw URLError(.fileDoesNotExist)
         }
-        try self.init(url: _url, extensions: extensions)
+        try self.init(url: _url, extensions: extensions, options: options)
     }
     
-    convenience public init(url: URL, extensions: [String:Codable.Type]? = nil) throws {
+    convenience public init(url: URL, extensions: [String:Codable.Type]? = nil, options: [GLTFLoadOption] = []) throws {
         let data = try Data(contentsOf: url)
         try self.init(data: data, extensions: extensions)
         self.directoryPath = url.deletingLastPathComponent()
+        self.options = options
     }
     
     public init(data: Data, extensions: [String:Codable.Type]? = nil) throws {
@@ -1017,27 +1025,19 @@ public class GLTFUnarchiver {
         }
         
 
-        if loadAlbedoOnly {
-            print("Load albedo only flag set to true! Skipping auxiliary materials")
-        } else {
-            if let normalTexture = glMaterial.normalTexture {
-                print("Skipping normal map")
-                
+
+        if let normalTexture = glMaterial.normalTexture, !options.contains(.skipNormalMap) {
                 try self.setTexture(index: normalTexture.index, to: material.normal)
                 material.normal.mappingChannel = normalTexture.texCoord
-                
                 // TODO: - use normalTexture.scale
             }
             
-            if let occlusionTexture = glMaterial.occlusionTexture {
-                print("Skipping AO map")
-                
+        if let occlusionTexture = glMaterial.occlusionTexture, !options.contains(.skipAOMap) {
                 try self.setTexture(index: occlusionTexture.index, to: material.ambientOcclusion)
                 material.ambientOcclusion.mappingChannel = occlusionTexture.texCoord
                 material.ambientOcclusion.intensity = CGFloat(occlusionTexture.strength)
-                
             }
-         }
+         
         
         if let emissiveTexture = glMaterial.emissiveTexture {
             if material.lightingModel == .physicallyBased {

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -37,6 +37,8 @@ public class GLTFUnarchiver {
     private var textures: [SCNMaterialProperty?] = []
     private var images: [Image?] = []
     private var maxAnimationDuration: CFTimeInterval = 0.0
+
+    private(set) loadAlbedoOnly = true
     
     #if !os(watchOS)
         private var workingAnimationGroup: CAAnimationGroup! = nil
@@ -953,6 +955,7 @@ public class GLTFUnarchiver {
         let glMaterial = materials[index]
         let material = SCNMaterial()
         self.materials[index] = material
+
         
         material.setValue(Float(1.0), forKey: "baseColorFactorR")
         material.setValue(Float(1.0), forKey: "baseColorFactorG")
@@ -964,6 +967,10 @@ public class GLTFUnarchiver {
         material.setValue(glMaterial.emissiveFactor[1], forKey: "emissiveFactorG")
         material.setValue(glMaterial.emissiveFactor[2], forKey: "emissiveFactorB")
         material.setValue(glMaterial.alphaCutoff, forKey: "alphaCutoff")
+
+        if loadAlbedoOnly {
+            print("Load albedo only flag set to true! Skipping auxiliary materials")
+        } else {
         
         if let pbr = glMaterial.pbrMetallicRoughness {
             material.lightingModel = .physicallyBased
@@ -1035,6 +1042,8 @@ public class GLTFUnarchiver {
             }
             try self.setTexture(index: emissiveTexture.index, to: material.emission)
             material.emission.mappingChannel = emissiveTexture.texCoord
+        }
+
         }
         
         material.isDoubleSided = glMaterial.doubleSided

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -811,9 +811,15 @@ public class GLTFUnarchiver {
             image = try loadImageData(from: bufferView)
         }
         
-        guard let _image = image else {
+        guard var _image = image else {
             throw GLTFUnarchiveError.Unknown("loadImage: image \(index) is not loaded")
         }
+        
+        #if canImport(UIKit)
+        if self.options.contains(.maxTextureSize4k) {
+            _image = _image.setMaxSize(maxSize: CGSize(width: 4096, height: 4096))
+        }
+        #endif
         
         self.images[index] = _image
         

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -817,7 +817,8 @@ public class GLTFUnarchiver {
         
         #if canImport(UIKit)
         if self.options.contains(.maxTextureSize4k) {
-            _image = _image.setMaxSize(maxSize: CGSize(width: 4096, height: 4096))
+           // _image = _image.setMaxSize(maxSize: CGSize(width: 4096, height: 4096))
+            UIImage.setMaxSize(image: &_image, maxSize: CGSize(width: 4096, height: 4096))
         }
         #endif
         

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -968,9 +968,7 @@ public class GLTFUnarchiver {
         material.setValue(glMaterial.emissiveFactor[2], forKey: "emissiveFactorB")
         material.setValue(glMaterial.alphaCutoff, forKey: "alphaCutoff")
 
-        if loadAlbedoOnly {
-            print("Load albedo only flag set to true! Skipping auxiliary materials")
-        } else {
+
         
         if let pbr = glMaterial.pbrMetallicRoughness {
             material.lightingModel = .physicallyBased
@@ -1018,23 +1016,28 @@ public class GLTFUnarchiver {
             
         }
         
-        if let normalTexture = glMaterial.normalTexture {
-            print("Skipping normal map")
-            /*
-            try self.setTexture(index: normalTexture.index, to: material.normal)
-            material.normal.mappingChannel = normalTexture.texCoord
-            */
-            // TODO: - use normalTexture.scale
-        }
-        
-        if let occlusionTexture = glMaterial.occlusionTexture {
-            print("Skipping AO map")
-            /*
-            try self.setTexture(index: occlusionTexture.index, to: material.ambientOcclusion)
-            material.ambientOcclusion.mappingChannel = occlusionTexture.texCoord
-            material.ambientOcclusion.intensity = CGFloat(occlusionTexture.strength)
-            */
-        }
+
+        if loadAlbedoOnly {
+            print("Load albedo only flag set to true! Skipping auxiliary materials")
+        } else {
+            if let normalTexture = glMaterial.normalTexture {
+                print("Skipping normal map")
+                
+                try self.setTexture(index: normalTexture.index, to: material.normal)
+                material.normal.mappingChannel = normalTexture.texCoord
+                
+                // TODO: - use normalTexture.scale
+            }
+            
+            if let occlusionTexture = glMaterial.occlusionTexture {
+                print("Skipping AO map")
+                
+                try self.setTexture(index: occlusionTexture.index, to: material.ambientOcclusion)
+                material.ambientOcclusion.mappingChannel = occlusionTexture.texCoord
+                material.ambientOcclusion.intensity = CGFloat(occlusionTexture.strength)
+                
+            }
+         }
         
         if let emissiveTexture = glMaterial.emissiveTexture {
             if material.lightingModel == .physicallyBased {
@@ -1044,7 +1047,7 @@ public class GLTFUnarchiver {
             material.emission.mappingChannel = emissiveTexture.texCoord
         }
 
-        }
+       
         
         material.isDoubleSided = glMaterial.doubleSided
         

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -38,7 +38,7 @@ public class GLTFUnarchiver {
     private var images: [Image?] = []
     private var maxAnimationDuration: CFTimeInterval = 0.0
 
-    private(set) loadAlbedoOnly = true
+    private(set) var loadAlbedoOnly = true
     
     #if !os(watchOS)
         private var workingAnimationGroup: CAAnimationGroup! = nil

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -1012,6 +1012,7 @@ public class GLTFUnarchiver {
         }
         
         if let normalTexture = glMaterial.normalTexture {
+            print("Loading normal texture")
             try self.setTexture(index: normalTexture.index, to: material.normal)
             material.normal.mappingChannel = normalTexture.texCoord
             
@@ -1019,6 +1020,7 @@ public class GLTFUnarchiver {
         }
         
         if let occlusionTexture = glMaterial.occlusionTexture {
+            print("Loading occlusion texture")
             try self.setTexture(index: occlusionTexture.index, to: material.ambientOcclusion)
             material.ambientOcclusion.mappingChannel = occlusionTexture.texCoord
             material.ambientOcclusion.intensity = CGFloat(occlusionTexture.strength)

--- a/Sources/Common/GLTFUnarchiver.swift
+++ b/Sources/Common/GLTFUnarchiver.swift
@@ -817,7 +817,6 @@ public class GLTFUnarchiver {
         
         #if canImport(UIKit)
         if self.options.contains(.maxTextureSize4k) {
-           // _image = _image.setMaxSize(maxSize: CGSize(width: 4096, height: 4096))
             UIImage.setMaxSize(image: &_image, maxSize: CGSize(width: 4096, height: 4096))
         }
         #endif

--- a/Sources/iOS/UIImageExtension.swift
+++ b/Sources/iOS/UIImageExtension.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Chris Heinrich on 8/3/21.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+
+extension UIImage {
+    func setMaxSize(maxSize: CGSize) -> UIImage {
+        let size = self.size
+        print("Original image size= \(size)")
+        print("Maximum image size= \(maxSize)")
+        let widthRatio = maxSize.width / size.width
+        let heightRatio = maxSize.height / size.height
+        if widthRatio >= 1.0, heightRatio >= 1.0 {
+            return self
+        }
+        
+        let resizeRatio = min(widthRatio, heightRatio)
+
+        let newSize = CGSize(width: size.width * resizeRatio, height: size.height * resizeRatio)
+        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+        draw(in: rect)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        print("Resized image size= \(newImage!.size)")
+        
+        return newImage!
+    }
+}
+
+
+
+
+
+
+
+#endif

--- a/Sources/iOS/UIImageExtension.swift
+++ b/Sources/iOS/UIImageExtension.swift
@@ -11,6 +11,29 @@ import Foundation
 import UIKit
 
 extension UIImage {
+    
+    static func setMaxSize(image: inout UIImage, maxSize: CGSize) {
+        let size = image.size
+        print("Original image size= \(size)")
+        print("Maximum image size= \(maxSize)")
+        let widthRatio = maxSize.width / size.width
+        let heightRatio = maxSize.height / size.height
+        if widthRatio >= 1.0, heightRatio >= 1.0 {
+            return
+        }
+        
+        let resizeRatio = min(widthRatio, heightRatio)
+
+        let newSize = CGSize(width: size.width * resizeRatio, height: size.height * resizeRatio)
+        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+        image.draw(in: rect)
+        image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        print("Resized image size= \(image.size)")
+    }
+    
+    
     func setMaxSize(maxSize: CGSize) -> UIImage {
         let size = self.size
         print("Original image size= \(size)")
@@ -27,11 +50,11 @@ extension UIImage {
         let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
         UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
         draw(in: rect)
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
-        print("Resized image size= \(newImage!.size)")
+        print("Resized image size= \(newImage.size)")
         
-        return newImage!
+        return newImage
     }
 }
 

--- a/Sources/iOS/UIImageExtension.swift
+++ b/Sources/iOS/UIImageExtension.swift
@@ -12,10 +12,12 @@ import UIKit
 
 extension UIImage {
     
+    /**
+     Resizes image in-place if image size exceeds maxSize
+     Otherwise does nothing
+     */
     static func setMaxSize(image: inout UIImage, maxSize: CGSize) {
         let size = image.size
-        print("Original image size= \(size)")
-        print("Maximum image size= \(maxSize)")
         let widthRatio = maxSize.width / size.width
         let heightRatio = maxSize.height / size.height
         if widthRatio >= 1.0, heightRatio >= 1.0 {
@@ -30,38 +32,7 @@ extension UIImage {
         image.draw(in: rect)
         image = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
-        print("Resized image size= \(image.size)")
-    }
-    
-    
-    func setMaxSize(maxSize: CGSize) -> UIImage {
-        let size = self.size
-        print("Original image size= \(size)")
-        print("Maximum image size= \(maxSize)")
-        let widthRatio = maxSize.width / size.width
-        let heightRatio = maxSize.height / size.height
-        if widthRatio >= 1.0, heightRatio >= 1.0 {
-            return self
-        }
-        
-        let resizeRatio = min(widthRatio, heightRatio)
-
-        let newSize = CGSize(width: size.width * resizeRatio, height: size.height * resizeRatio)
-        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
-        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
-        draw(in: rect)
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()!
-        UIGraphicsEndImageContext()
-        print("Resized image size= \(newImage.size)")
-        
-        return newImage
     }
 }
-
-
-
-
-
-
 
 #endif

--- a/Sources/iOS/UIImageExtension.swift
+++ b/Sources/iOS/UIImageExtension.swift
@@ -18,6 +18,9 @@ extension UIImage {
      */
     static func setMaxSize(image: inout UIImage, maxSize: CGSize) {
         let size = image.size
+        if size.width == 0 || size.height == 0 {
+            return
+        }
         let widthRatio = maxSize.width / size.width
         let heightRatio = maxSize.height / size.height
         if widthRatio >= 1.0, heightRatio >= 1.0 {


### PR DESCRIPTION
Adds options to the GLTFUnarchiver to skip normal and AO maps and to resize textures larger than 4k down to 4k, cuts down memory consumption while rendering meshes with 8k textures by about 80%, and the meshes actually look better in our renderer without the AO/normal maps because we dont use lighting